### PR TITLE
fix : change item import , and reflect the library name change of structured-instruction lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "substreams-solana-structured-instructions"
 version = "0.1.0"
-source = "git+https://github.com/0xpapercut/substreams-solana-structured-instructions?branch=main#6e3f7c2d29bbae90274ce2d6d01ded90c6cfb2d5"
+source = "git+https://github.com/0xpapercut/substreams-solana-structured-instructions?branch=main#620ae0302572c20d2c77ea1c04a40c40c52722fb"
 dependencies = [
  "substreams",
  "substreams-solana",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use structured_instructions::{
+use substreams_solana_structured_instructions::{
     get_structured_instructions, StructuredInstruction, StructuredInstructions
 };
 


### PR DESCRIPTION
  Hey
  I wanted to use your raydium substream as a base template to develop my own substream program for another program, but the build was broken as the library name changes for structured instructions werent updated in the solana-utils package.